### PR TITLE
Fixed double with exponent parsing. It was crashing when attempting t…

### DIFF
--- a/src/main/java/com/eclipsesource/json/JsonParser.java
+++ b/src/main/java/com/eclipsesource/json/JsonParser.java
@@ -42,7 +42,9 @@ public class JsonParser {
     private long fractionPart;
     private short exponentPart;
     private byte fractionCount;
+    private byte capturedFractionCountBuffer;
     private boolean isPositive;
+    private boolean isExponentPositive;
     private int captureStart;
     private CachedJsonString.KeyFromBuffer reusedCachedJsonStringKey;
 
@@ -292,13 +294,15 @@ public class JsonParser {
         isPositive = readSign();
         integerPart = readInteger();
         fractionPart = readFraction();
+        capturedFractionCountBuffer = fractionCount; // Reading the exponent will alter the real fractionCount value
         exponentPart = readExponent();
+        exponentPart = isExponentPositive ? exponentPart : (short) (-1 * exponentPart);
 
-        if (fractionCount == 0 && exponentPart == 0 && integerPart > Integer.MIN_VALUE && integerPart < Integer.MAX_VALUE) {
+        if (capturedFractionCountBuffer == 0 && exponentPart == 0 && integerPart > Integer.MIN_VALUE && integerPart < Integer.MAX_VALUE) {
             return new JsonInt((int) (isPositive ? integerPart : -1 * integerPart));
         }
 
-        return new OptimizedJsonNumber(integerPart, fractionPart, fractionCount, exponentPart, isPositive);
+        return new OptimizedJsonNumber(integerPart, fractionPart, capturedFractionCountBuffer, exponentPart, isPositive);
     }
 
     private boolean readSign() throws IOException {
@@ -341,6 +345,7 @@ public class JsonParser {
         if (!readChar('e') && !readChar('E')) {
             return 0;
         }
+        isExponentPositive = readSign();
         return (short) readInteger();
     }
 

--- a/src/main/java/com/eclipsesource/json/JsonParser.java
+++ b/src/main/java/com/eclipsesource/json/JsonParser.java
@@ -296,7 +296,6 @@ public class JsonParser {
         fractionPart = readFraction();
         capturedFractionCountBuffer = fractionCount; // Reading the exponent will alter the real fractionCount value
         exponentPart = readExponent();
-        exponentPart = isExponentPositive ? exponentPart : (short) (-1 * exponentPart);
 
         if (capturedFractionCountBuffer == 0 && exponentPart == 0 && integerPart > Integer.MIN_VALUE && integerPart < Integer.MAX_VALUE) {
             return new JsonInt((int) (isPositive ? integerPart : -1 * integerPart));
@@ -346,7 +345,9 @@ public class JsonParser {
             return 0;
         }
         isExponentPositive = readSign();
-        return (short) readInteger();
+        short exponent = (short) readInteger();
+        return isExponentPositive ? exponent : (short) (-1 * exponent);
+
     }
 
     private boolean readChar(char ch) throws IOException {

--- a/src/main/java/com/eclipsesource/json/OptimizedJsonNumber.java
+++ b/src/main/java/com/eclipsesource/json/OptimizedJsonNumber.java
@@ -96,7 +96,11 @@ class OptimizedJsonNumber extends JsonValue {
     }
 
     private double fullDouble() {
-        return integerPart * Math.pow(10, exponentPart) + fractionPart * Math.pow(10, exponentPart - fractionScale);
+        if (isPositive) {
+            return integerPart * Math.pow(10, exponentPart) + fractionPart * Math.pow(10, exponentPart - fractionScale);
+        } else {
+            return -1 * (Math.abs(integerPart) * Math.pow(10, exponentPart) + fractionPart * Math.pow(10, exponentPart - fractionScale));
+        }
     }
 
     @Override

--- a/src/test/java/com/eclipsesource/json/JsonParserTest.java
+++ b/src/test/java/com/eclipsesource/json/JsonParserTest.java
@@ -1,0 +1,55 @@
+package com.eclipsesource.json;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class JsonParserTest {
+
+    @Test
+    public void parsePositiveExponentNumber() throws Exception {
+        Assert.assertEquals(25000, parseValue("2.5e4").asDouble(), 1e-10);
+    }
+
+    @Test
+    public void parseNegativeExponentNumber() throws Exception {
+        Assert.assertEquals(0.00025d, parseValue("2.5e-4").asDouble(), 1e-10);
+    }
+
+    @Test
+    public void parseNegativeNumberWithPositiveExponent() throws Exception {
+        Assert.assertEquals(-25000d, parseValue("-2.5e4").asDouble(), 1e-10);
+    }
+
+    @Test
+    public void parseNegativeNumberWithNegativeExponent() throws Exception {
+        Assert.assertEquals(-0.00025d, parseValue("-2.5e-4").asDouble(), 1e-10);
+    }
+
+    @Test
+    public void parseInteger() throws Exception {
+        Assert.assertEquals(10, parseValue("10").asInt(), 1e-10);
+    }
+
+    @Test
+    public void parseNegativeInteger() throws Exception {
+        Assert.assertEquals(-10, parseValue("-10").asInt(), 1e-10);
+    }
+
+    @Test
+    public void parseIntegerWithFraction() throws Exception {
+        Assert.assertEquals(10.05d, parseValue("10.05").asDouble(), 1e-10);
+    }
+
+    @Test
+    public void parseNegativeIntegerWithFraction() throws Exception {
+        Assert.assertEquals(-10.05d, parseValue("-10.05").asDouble(), 1e-10);
+    }
+
+    private JsonValue parseValue(String value) throws IOException {
+        JsonParser jsonParser = new JsonParser("{\"value\": " + value + "}");
+        return jsonParser.parse().asObject().get("value");
+    }
+
+}

--- a/src/test/java/com/eclipsesource/json/OptimizedJsonNumberTest.java
+++ b/src/test/java/com/eclipsesource/json/OptimizedJsonNumberTest.java
@@ -13,7 +13,7 @@ public class OptimizedJsonNumberTest {
 
         assertEquals("123.4567e2", number.toString());
         assertEquals(12345, number.asInt());
-        assertEquals(12345l, number.asLong());
+        assertEquals(12345L, number.asLong());
         assertEquals(12345.67f, number.asFloat(), 1e-3);
         assertEquals(12345.67, number.asDouble(), 1e-10);
     }
@@ -25,7 +25,7 @@ public class OptimizedJsonNumberTest {
 
         assertEquals("12345", number.toString());
         assertEquals(12345, number.asInt());
-        assertEquals(12345l, number.asLong());
+        assertEquals(12345L, number.asLong());
         assertEquals(12345f, number.asFloat(), 1e-3);
         assertEquals(12345d, number.asDouble(), 1e-10);
     }
@@ -37,9 +37,33 @@ public class OptimizedJsonNumberTest {
 
         assertEquals("12345e-2", number.toString());
         assertEquals(123, number.asInt());
-        assertEquals(123l, number.asLong());
+        assertEquals(123L, number.asLong());
         assertEquals(123.45f, number.asFloat(), 1e-3);
         assertEquals(123.45d, number.asDouble(), 1e-10);
+    }
+
+    @Test
+    public void test_negative_integer_with_exp(){
+        // -2.5e4
+        OptimizedJsonNumber number = new OptimizedJsonNumber(2, 5, (byte) 1, (short) 4, false);
+
+        assertEquals("-2.5e4", number.toString());
+        assertEquals(-25000, number.asInt());
+        assertEquals(-25000L, number.asLong());
+        assertEquals(-25000f, number.asFloat(), 1e-3);
+        assertEquals(-25000d, number.asDouble(), 1e-10);
+    }
+
+    @Test
+    public void test_negative_integer_with_negative_exp(){
+        // -2.5e-4
+        OptimizedJsonNumber number = new OptimizedJsonNumber(2, 5, (byte) 1, (short) -4, false);
+
+        assertEquals("-2.5e-4", number.toString());
+        assertEquals(0, number.asInt());
+        assertEquals(0, number.asLong());
+        assertEquals(-0.00025f, number.asFloat(), 1e-3);
+        assertEquals(-0.00025d, number.asDouble(), 1e-10);
     }
 
     @Test
@@ -49,7 +73,7 @@ public class OptimizedJsonNumberTest {
 
         assertEquals("12345.6789", number.toString());
         assertEquals(12345, number.asInt());
-        assertEquals(12345l, number.asLong());
+        assertEquals(12345L, number.asLong());
         assertEquals(12345.6789f, number.asFloat(), 1e-3);
         assertEquals(12345.6789d, number.asDouble(), 1e-10);
     }
@@ -61,7 +85,7 @@ public class OptimizedJsonNumberTest {
 
         assertEquals("-73.5716511", number.toString());
         assertEquals(-73, number.asInt());
-        assertEquals(-73l, number.asLong());
+        assertEquals(-73L, number.asLong());
         assertEquals(-73.5716f, number.asFloat(), 1e-3);
         assertEquals(-73.5716511d, number.asDouble(), 1e-10);
     }
@@ -69,11 +93,11 @@ public class OptimizedJsonNumberTest {
     @Test
     public void test_high_precision_double() {
         // 45.5122363923859
-        OptimizedJsonNumber number = new OptimizedJsonNumber(45, 5122363923859l, (byte) 13, (short) 0, true);
+        OptimizedJsonNumber number = new OptimizedJsonNumber(45, 5122363923859L, (byte) 13, (short) 0, true);
 
         assertEquals("45.5122363923859", number.toString());
         assertEquals(45, number.asInt());
-        assertEquals(45l, number.asLong());
+        assertEquals(45L, number.asLong());
         assertEquals(45.5122f, number.asFloat(), 1e-3);
         assertEquals(45.5122363923859d, number.asDouble(), 1e-10);
     }
@@ -85,7 +109,7 @@ public class OptimizedJsonNumberTest {
 
         assertEquals("0.6789", number.toString());
         assertEquals(0, number.asInt());
-        assertEquals(0l, number.asLong());
+        assertEquals(0L, number.asLong());
         assertEquals(0.6789f, number.asFloat(), 1e-3);
         assertEquals(0.6789d, number.asDouble(), 1e-10);
     }
@@ -97,7 +121,7 @@ public class OptimizedJsonNumberTest {
 
         assertEquals("-0.6789", number.toString());
         assertEquals(0, number.asInt());
-        assertEquals(0l, number.asLong());
+        assertEquals(0L, number.asLong());
         assertEquals(-0.6789f, number.asFloat(), 1e-3);
         assertEquals(-0.6789d, number.asDouble(), 1e-10);
     }


### PR DESCRIPTION
…o parse a negative exponent. Additionally, the handling of a exponents was not properly implemented in OptimizedJsonNumber for negative numbers.